### PR TITLE
Add replace config to composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,6 @@
         "classmap": [ "tests" ]
     },
     "replace": {
-        "danielstjules/stringy": "1.1.0"
+        "danielstjules/stringy": "1.10.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -36,5 +36,8 @@
     },
     "autoload-dev": {
         "classmap": [ "tests" ]
+    },
+    "replace": {
+        "danielstjules/stringy": "1.1.0"
     }
 }


### PR DESCRIPTION
This will help override `danielstjules/stringy` better than the hacky method that's been used in the composer.lock file, which can easily get blown away if you are into updating your Composer dependencies